### PR TITLE
Added a firmware check in the DetermineBaselines function

### DIFF
--- a/build/config.h
+++ b/build/config.h
@@ -70,7 +70,7 @@
 #define HAVE_UNISTD_H 1
 
 /* Compile standalone slave */
-/* #undef KLITE */
+#define KLITE 1
 
 /* Define to the sub-directory in which libtool stores uninstalled libraries.
    */
@@ -107,7 +107,7 @@
 /* #undef WITH_DDC10 */
 
 /* Compile master module */
-#define WITH_MASTER /**/
+/* #undef WITH_MASTER */
 
 /* Compile slave module */
-#define WITH_SLAVE /**/
+/* #undef WITH_SLAVE */

--- a/src/slave/CBV1724.cc
+++ b/src/slave/CBV1724.cc
@@ -465,10 +465,10 @@ int CBV1724::DetermineBaselines()
     
     // Enable to board
     WriteReg32(CBV1724_AcquisitionControlReg,0x4);
-    //usleep(5000); //
+    if(fwVERSION==0) usleep(5000); //
     //Set Software Trigger
     WriteReg32(CBV1724_SoftwareTriggerReg,0x1);
-    //usleep(5000); //
+    if(fwVERSION==0) usleep(5000); //
     //Disable the board
     WriteReg32(CBV1724_AcquisitionControlReg,0x0);
     //usleep(5000);

--- a/src/slave/CBV1724.cc
+++ b/src/slave/CBV1724.cc
@@ -465,10 +465,10 @@ int CBV1724::DetermineBaselines()
     
     // Enable to board
     WriteReg32(CBV1724_AcquisitionControlReg,0x4);
-    if(fwVERSION==0) usleep(5000); //
+    if(fwVERSION==0) usleep(1500); //
     //Set Software Trigger
     WriteReg32(CBV1724_SoftwareTriggerReg,0x1);
-    if(fwVERSION==0) usleep(5000); //
+    if(fwVERSION==0) usleep(1500); //
     //Disable the board
     WriteReg32(CBV1724_AcquisitionControlReg,0x0);
     //usleep(5000);


### PR DESCRIPTION
Added a firmware version check in front of the usleep(5000) in the DetermineBaselines function of the CBV1724 class.
This usleep command is needed by the old firmware, but not by the new one.